### PR TITLE
Add submodule-related commands to justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ The Python language bindings for the [bitcoindevkit](https://github.com/bitcoind
 
 See the [package on PyPI](https://pypi.org/project/bdkpython/).
 
+# Working with the submodule
+
+This repository uses the bdk-ffi repository as a git submodule. Here are useful tips for working with the submodule:
+
+1. When initially cloning the repo, the `bdk-ffi` submodule will be empty locally. You can intitiate/populate the directory by using the `just submodule-init` command.
+2. If you make local changes to the `bdk-ffi` directory while developing and want to hard delete all changes and return to the exact committed version hash of the bdk-ffi repo, use the `just submodule-reset` command.
+
 ## Local Testing and Usage
 
 1. Start a Python virtual environment

--- a/justfile
+++ b/justfile
@@ -16,6 +16,16 @@ clean:
   rm -rf ./build/
   rm -rf ./dist/
 
+[group("Submodule")]
+[doc("Initialize bdk-ffi submodule to committed hash.")]
+submodule-init:
+  git submodule update --init
+
+[group("Submodule")]
+[doc("Hard reset the bdk-ffi submodule to committed hash.")]
+submodule-reset:
+  git submodule update --force
+
 [group("Test")]
 [doc("Run all tests.")]
 test:


### PR DESCRIPTION
Fixes #6.

This PR add two commands to work with the submodule:

```
[group("Submodule")]
[doc("Initialize bdk-ffi submodule to committed hash.")]
submodule-init:
  git submodule update --init

[group("Submodule")]
[doc("Hard reset the bdk-ffi submodule to committed hash.")]
submodule-reset:
  git submodule update --force
```