### PR TITLE
build: add submodule update-to-master just command

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,14 @@ submodule-init:
 submodule-reset:
   git submodule update --force
 
+[group("Submodule")]
+[doc("Checkout the bdk-ffi submodule to the latest commit on master.")]
+submodule-to-master:
+  cd ./bdk-ffi/ \
+  && git fetch origin \
+  && git checkout master \
+  && git pull origin master
+
 [group("Test")]
 [doc("Run all tests.")]
 test:


### PR DESCRIPTION
This PR adds a new just command that pulls the latest commit on master from bdk-ffi. This makes it easy for devs to test out the latest changes to the submodule. Note that they can then revert back to the currently committed commit hash of the submodule using `submodule-reset`.